### PR TITLE
Spark 2.0.0 + ScalaTest 3.0.0 + updates sbt plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,3 @@
-// Your sbt build file. Guides on how to write one can be found at
-// http://www.scala-sbt.org/0.13/docs/index.html
-
-//import sbtprotobuf.{ProtobufPlugin=>PB}
 import Dependencies._
 
 resolvers += "ASF repository" at "http://repository.apache.org/snapshots"
@@ -31,14 +27,14 @@ spIncludeMaven := false
 
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))
 
-spShortDescription := "Tensorflow wrapper for DataFrames on Apache Spark"
+spShortDescription := "TensorFlow wrapper for DataFrames on Apache Spark"
 
 spDescription := {
-  """TensorFrames (TensorFlow on Spark Dataframes) lets you manipulate Spark's DataFrames with
+  """TensorFrames (TensorFlow on Spark DataFrames) lets you manipulate Spark's DataFrames with
     | TensorFlow programs.
     |
     |This package provides a small runtime to express and run TensorFlow computation graphs.
-    |Tensorflow programs can be interpreted from:
+    |TensorFlow programs can be interpreted from:
     | - the official Python API
     | - the semi-official protocol buffer graph description format
     | - the Scala DSL embedded with TensorFrames (experimental)
@@ -60,7 +56,8 @@ libraryDependencies += "org.apache.spark" %% "spark-core" % targetSparkVersion %
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % targetSparkVersion % "provided"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.3" % "test"
+libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.0"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 
 libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.4"
 
@@ -79,7 +76,7 @@ libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "
 
 // Could not get protobuf to work -> manually adding it
 
-libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.0.0-beta-1"
+libraryDependencies += "com.google.protobuf" % "protobuf-java" % "3.0.0"
 
 libraryDependencies += "org.bytedeco" % "javacpp" % targetJCPPVersion
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ import xml.transform.{RuleTransformer, RewriteRule}
 
 object Dependencies {
   // The spark version
-  val targetSparkVersion = "2.0.0-SNAPSHOT"
+  val targetSparkVersion = "2.0.0"
 
   val targetJCPPVersion = "1.2"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-// This file should only contain the version of sbt to use.
-sbt.version=0.13.11
+sbt.version=0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,8 @@
-// You may use this file to add plugin dependencies for sbt.
 resolvers += "Spark Packages repo" at "https://dl.bintray.com/spark-packages/maven/"
 
-addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.3")
-
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
+addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.4")
 
 // You need protoc3 for this to work
-addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.4.0")
+addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.5.3")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")

--- a/src/test/scala/org/tensorframes/CommonOperationsSuite.scala
+++ b/src/test/scala/org/tensorframes/CommonOperationsSuite.scala
@@ -1,6 +1,5 @@
 package org.tensorframes
 
-import org.tensorframes.Logging
 import org.apache.spark.sql.Row
 import org.scalatest.FunSuite
 import org.tensorframes.impl.{SupportedOperations, ScalarTypeOperation, DebugRowOps}

--- a/src/test/scala/org/tensorframes/DSLOperationsSuite.scala
+++ b/src/test/scala/org/tensorframes/DSLOperationsSuite.scala
@@ -4,7 +4,6 @@ import org.scalatest.FunSuite
 import org.tensorframes.dsl._
 import org.tensorframes.dsl.Implicits._
 
-import org.tensorframes.Logging
 import org.apache.spark.sql.Row
 
 class DSLOperationsSuite

--- a/src/test/scala/org/tensorframes/DebugRowOpsSuite.scala
+++ b/src/test/scala/org/tensorframes/DebugRowOpsSuite.scala
@@ -1,6 +1,5 @@
 package org.tensorframes
 
-import org.tensorframes.Logging
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DoubleType, StructType}
 import org.scalatest.FunSuite

--- a/src/test/scala/org/tensorframes/ExtraOperationsSuite.scala
+++ b/src/test/scala/org/tensorframes/ExtraOperationsSuite.scala
@@ -1,6 +1,5 @@
 package org.tensorframes
 
-import org.tensorframes.Logging
 import org.apache.spark.sql.types.{DoubleType, IntegerType}
 import org.scalatest.FunSuite
 

--- a/src/test/scala/org/tensorframes/SlicingSuite.scala
+++ b/src/test/scala/org/tensorframes/SlicingSuite.scala
@@ -6,7 +6,6 @@ import org.tensorframes.impl.DebugRowOps
 import org.tensorframes.{dsl => tf}
 import org.tensorframes.dsl.Implicits._
 
-import org.tensorframes.Logging
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{DoubleType, IntegerType}
 

--- a/src/test/scala/org/tensorframes/TFInitializationSuite.scala
+++ b/src/test/scala/org/tensorframes/TFInitializationSuite.scala
@@ -1,6 +1,5 @@
 package org.tensorframes
 
-import org.tensorframes.Logging
 import org.scalatest.FunSuite
 import org.tensorframes.impl.TensorFlowOps
 

--- a/src/test/scala/org/tensorframes/TrimmingOperationsSuite.scala
+++ b/src/test/scala/org/tensorframes/TrimmingOperationsSuite.scala
@@ -1,6 +1,5 @@
 package org.tensorframes
 
-import org.tensorframes.Logging
 import org.apache.spark.sql.Row
 import org.scalatest.FunSuite
 import org.tensorframes.dsl.GraphScoping

--- a/src/test/scala/org/tensorframes/dsl/ExtractNodes.scala
+++ b/src/test/scala/org/tensorframes/dsl/ExtractNodes.scala
@@ -4,11 +4,11 @@ import java.io.{BufferedReader, InputStreamReader, File}
 import java.nio.file.Files
 import java.nio.charset.StandardCharsets
 import org.tensorframes.Logging
-import org.scalatest.ShouldMatchers
+import org.scalatest.Matchers
 
 import scala.collection.JavaConverters._
 
-object ExtractNodes extends ShouldMatchers with Logging {
+object ExtractNodes extends Matchers with Logging {
 
   def executeCommand(py: String): Map[String, String] = {
     val content =


### PR DESCRIPTION
The subject says it all.

WARNING: `doit` works (since it disabled tests in `assembly`), but I could not get `sbt test` working. It fails with the following error which is more about TensorFlow that I know nothing about:

```
➜  tensorframes git:(spark-200-and-other-upgrades) sbt
[info] Loading global plugins from /Users/jacek/.sbt/0.13/plugins
[info] Loading project definition from /Users/jacek/dev/oss/tensorframes/project
[info] Set current project to tensorframes (in build file:/Users/jacek/dev/oss/tensorframes/)
> testOnly org.tensorframes.dsl.BasicOpsSuite
16/08/04 23:52:22 DEBUG Paths$: Request for x -> 0
16/08/04 23:52:22 DEBUG Paths$: Request for y -> 0
16/08/04 23:52:22 DEBUG Paths$: Request for z -> 0

import tensorflow as tf

x = tf.constant(1, name='x')
y = tf.constant(2, name='y')
z = tf.add(x, y, name='z')
      
g = tf.get_default_graph().as_graph_def()
for n in g.node:
    print ">>>>>", str(n.name), "<<<<<<"
    print n
       
[info] BasicOpsSuite:
[info] - Add *** FAILED ***
[info]   1 did not equal 0 (1,===========
[info]   
[info]   import tensorflow as tf
[info]   
[info]   x = tf.constant(1, name='x')
[info]   y = tf.constant(2, name='y')
[info]   z = tf.add(x, y, name='z')
[info]         
[info]   g = tf.get_default_graph().as_graph_def()
[info]   for n in g.node:
[info]       print ">>>>>", str(n.name), "<<<<<<"
[info]       print n
[info]          
[info]   ===========) (ExtractNodes.scala:40)
[info] Run completed in 1 second, 772 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 0, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed tests:
[error]         org.tensorframes.dsl.BasicOpsSuite
[error] (test:testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 2 s, completed Aug 4, 2016 11:52:22 PM
```

I'm proposing the PR hoping the issue is a minor one that could easily be fixed with enough guidance.