### PR TITLE
Update version numbers from 0.2.8 to 0.2.9-rc0 for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Additionally, if you want to run unit tests for python, you need the following d
 Assuming that `SPARK_HOME` is set, you can use PySpark like any other Spark package.
 
 ```bash
-$SPARK_HOME/bin/pyspark --packages databricks:tensorframes:0.2.8-s_2.11
+$SPARK_HOME/bin/pyspark --packages databricks:tensorframes:0.2.9-rc0-s_2.11
 ```
 
 Here is a small program that uses Tensorflow to add 3 to an existing column.
@@ -150,7 +150,7 @@ The scala support is a bit more limited than python. In scala, operations can be
 You simply use the published package:
 
 ```bash
-$SPARK_HOME/bin/spark-shell --packages databricks:tensorframes:0.2.8
+$SPARK_HOME/bin/spark-shell --packages databricks:tensorframes:0.2.9-rc0
 ```
 
 Here is the same program as before:
@@ -200,14 +200,14 @@ build/sbt distribution/spDist
 Assuming that SPARK_HOME is set and that you are in the root directory of the project:
 
 ```bash
-$SPARK_HOME/bin/spark-shell --jars $PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.8.jar
+$SPARK_HOME/bin/spark-shell --jars $PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.9-rc0.jar
 ```
 
 If you want to run the python version:
  
 ```bash
-PYTHONPATH=$PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.8.jar \
-$SPARK_HOME/bin/pyspark --jars $PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.8.jar
+PYTHONPATH=$PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.9-rc0.jar \
+$SPARK_HOME/bin/pyspark --jars $PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.9-rc0.jar
 ```
 
 ## Acknowledgements

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,7 +11,7 @@ object Shading extends Build {
 
 
   lazy val commonSettings = Seq(
-    version := "0.2.8",
+    version := "0.2.9-rc0",
     name := "tensorframes",
     scalaVersion := sys.props.getOrElse("scala.version", "2.11.8"),
     organization := "databricks",


### PR DESCRIPTION
Update all version numbers in Tensorframes from 0.2.8 to 0.2.9-rc0 in preparation for release.