### PR TITLE
Shade google.protobuf classes in addition to com.google.protobuf classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Additionally, if you want to run unit tests for python, you need the following d
 Assuming that `SPARK_HOME` is set, you can use PySpark like any other Spark package.
 
 ```bash
-$SPARK_HOME/bin/pyspark --packages databricks:tensorframes:0.2.9-rc1-s_2.11
+$SPARK_HOME/bin/pyspark --packages databricks:tensorframes:0.2.9-rc2-s_2.11
 ```
 
 Here is a small program that uses Tensorflow to add 3 to an existing column.
@@ -152,7 +152,7 @@ The scala support is a bit more limited than python. In scala, operations can be
 You simply use the published package:
 
 ```bash
-$SPARK_HOME/bin/spark-shell --packages databricks:tensorframes:0.2.9-rc1
+$SPARK_HOME/bin/spark-shell --packages databricks:tensorframes:0.2.9-rc2
 ```
 
 Here is the same program as before:
@@ -202,14 +202,14 @@ build/sbt distribution/spDist
 Assuming that SPARK_HOME is set and that you are in the root directory of the project:
 
 ```bash
-$SPARK_HOME/bin/spark-shell --jars $PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.9-rc1.jar
+$SPARK_HOME/bin/spark-shell --jars $PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.9-rc2.jar
 ```
 
 If you want to run the python version:
  
 ```bash
-PYTHONPATH=$PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.9-rc1.jar \
-$SPARK_HOME/bin/pyspark --jars $PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.9-rc1.jar
+PYTHONPATH=$PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.9-rc2.jar \
+$SPARK_HOME/bin/pyspark --jars $PWD/target/testing/scala-2.11/tensorframes-assembly-0.2.9-rc2.jar
 ```
 
 ## Acknowledgements

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,7 +11,7 @@ object Shading extends Build {
 
 
   lazy val commonSettings = Seq(
-    version := "0.2.9-rc1",
+    version := "0.2.9-rc2",
     name := "tensorframes",
     scalaVersion := sys.props.getOrElse("scala.version", "2.11.8"),
     organization := "databricks",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -73,7 +73,8 @@ object Shading extends Build {
     libraryDependencies ++= testDependencies,
     libraryDependencies ++= allPlatformDependencies,
     assemblyShadeRules in assembly := Seq(
-      ShadeRule.rename("com.google.protobuf.**" -> "org.tensorframes.protobuf3shade.@1").inAll
+      ShadeRule.rename("com.google.protobuf.**" -> "org.tensorframes.protobuf3shade.@1").inAll,
+      ShadeRule.rename("google.protobuf.**" -> "org.tensorframes.google.protobuf3shade.@1").inAll
     ),
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
   ).settings(commonSettings: _*)


### PR DESCRIPTION
Adds a shade rule to rename google:proto classes packaged with tensorframes. These classes previously conflicted with google:proto classes downloaded as dependencies of tensorflow:proto (which tensorframes now depends on).