### PR TITLE
[ML-5969] Update publishing dependencies

### DIFF
--- a/dev/release.py
+++ b/dev/release.py
@@ -8,7 +8,7 @@ DATABRICKS_REMOTE = "git@github.com:databricks/tensorframes.git"
 PUBLISH_MODES = {
     "local": "tfs_testing/publishLocal",
     "m2": "tfs_testing/publishM2",
-    "spark-package-publish": "distribution/spPublish",
+    "spark-package-publish": "distribution/spDist",
 }
 
 WORKING_BRANCH = "WORKING_BRANCH_RELEASE_%s_@%s"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -113,7 +113,7 @@ object Shading extends Build {
     spHomepage := "https://github.com/databricks/tensorframes",
     spShade := true,
     assembly in spPackage := (assembly in shaded).value,
-    credentials += Credentials(Path.userHome / ".ssh" / "credentials_tensorframes.sbt.txt")
+    credentials += Credentials(Path.userHome / ".spark-packages-credential")
   ).settings(commonSettings: _*)
   .enablePlugins(ProtobufPlugin)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -113,7 +113,7 @@ object Shading extends Build {
     spHomepage := "https://github.com/databricks/tensorframes",
     spShade := true,
     assembly in spPackage := (assembly in shaded).value,
-    credentials += Credentials(Path.userHome / ".spark-packages-credential")
+    credentials += Credentials(Path.userHome / ".ssh" / "credentials_tensorframes.sbt.txt")
   ).settings(commonSettings: _*)
   .enablePlugins(ProtobufPlugin)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Spark Packages repo" at "https://dl.bintray.com/spark-packages/maven/"
 
-addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.5")
+addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.6")
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 


### PR DESCRIPTION
Use spDist with manual upload to publish instead of spPublish because the upload step of spDist is flaky.