### PR TITLE
[ML-7854] Use python3.7 in dockerfile and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - DOCKER_COMPOSE_VERSION=1.22.0
   matrix:
-    - PYTHON_VERSION=3.6
+    - PYTHON_VERSION=3.7
     - PYTHON_VERSION=2.7
 
 before_install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM ubuntu:16.04
 
-ARG PYTHON_VERSION=3.6
+ARG PYTHON_VERSION=3.7
 
 RUN apt-get update && \
     apt-get install -y wget bzip2 openjdk-8-jdk unzip && \

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ the root of project:
 conda create -q -n tensorframes-environment python=$PYTHON_VERSION
 ```
 
-This will create an environment for your project. We recommend using Python version 3.6.2 or 2.7.13.
+This will create an environment for your project. We recommend using Python version 3.7 or 2.7.13.
 After the environemnt is created, you can activate it and install all dependencies as follows:
 
 ```bash

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 # To choose a Python version, first create the env with:
-# conda create -n tensorframes python=3.6
+# conda create -n tensorframes python=3.7
 # and then update it
 name: tensorframes
 channels:

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ name: tensorframes
 channels:
 - https://repo.anaconda.com/pkgs/main/linux-64/
 dependencies:
-- pandas=0.23.4
+- pandas=0.24.2
 - nomkl
 - protobuf=3.6.1
 - tensorflow=1.13.1


### PR DESCRIPTION
ML Runtime uses python3.7 now, so it would be best to test against the same version of python here.

